### PR TITLE
Simplify variables used in the role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ansible Role: mirsg.install_python
 
-This role installs Python, pip, and setuptools on Debian and RedHat operating systems. It will also update pip to the latest version.
+This role installs Python, pip, and setuptools on Debian and RedHat operating systems. It will also update pip to the latest version or a
+user-specified version, and then install user-specified Python packages using pip.
 
 ## Requirements
 
@@ -24,11 +25,13 @@ If you would like to run Ansible Molecule to test this role, the requirements ar
 - python-setuptools
 ```
 
-`extra_python3_packages`: list of additional Python 3 packages to to be installed by the OS package manager, NOT by pip
-`extra_python2_packages`: list of additional Python 2 packages to to be installed by the OS package manager, NOT by pip
+The packages listed in the above variables will be installed by the OS package manager, NOT by pip.
 
-`python3_pip_packages`: list of Python 3 packages to be installed by pip
-`python2_pip_packages`: list of Python 2 packages to be installed by pip
+`install_pip_version`: version of pip to update to, defaults to `latest`.
+
+`python3_pip_packages`: list of Python 3 packages to be installed by pip, default to `[]`.
+
+`python2_pip_packages`: list of Python 2 packages to be installed by pip, defaults to `[]`.
 
 ## Dependencies
 
@@ -45,6 +48,16 @@ should be installed on your managed host. As such, you will need to gather these
 - name: Install Python 3
   hosts: all
   gather_facts: true
+  roles:
+    - mirsg.install_python
+```
+
+This will gather all facts before installing Python. If you would like to install only the necessary facts (`ansible_os_family` and `ansible_distribution_major_version`) to run the role and install Python, you can use `gather_subset`:
+
+```yaml
+- name: Install Python 3
+  hosts: all
+  gather_facts: true
   gather_subset:
     - "os_family"
     - "distribution_major_version"
@@ -53,8 +66,6 @@ should be installed on your managed host. As such, you will need to gather these
   roles:
     - mirsg.install_python
 ```
-
-This will gather only the necessary facts (`ansible_os_family` and `ansible_distribution_major_version`) to run the role and install Python.
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 install_python_version: 3
+install_pip_version: "latest"
 
 install_python3_packages:
   - python3
@@ -10,9 +11,6 @@ install_python2_packages:
   - python
   - python-pip
   - python-setuptools
-
-extra_python2_packages: [] # to be installed by the OS package manager, NOT by pip
-extra_python3_packages: [] # to be installed by the OS package manager, NOT by pip
 
 python2_pip_packages: [] # to be installed using pip
 python3_pip_packages: [] # to be installed using pip3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,37 @@
 ---
 # tasks file for ansible-role-install-python3
-- name: Install Python for the current OS family
+- name: Prepare to install Python for the current OS family
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: Install Python 2 and associated packages if necessary
+- name: Install Python 2 and associated packages if necessary # noqa: var-spacing
   ansible.builtin.package:
     name: "{{ item.name | default(item) }}"
     update_cache: true
     state: present
-  loop: "{{ install_python2_packages + extra_python2_packages }}"
+  loop: "{{ install_python2_packages}}"
   when: install_python_version == 2
 
-- name: Install Python 3 and associated packages if necessary
+- name: Install Python 3 and associated packages if necessary # noqa: var-spacing
   ansible.builtin.package:
     name: "{{ item.name | default(item) }}"
     update_cache: true
     state: present
-  loop: "{{ install_python3_packages + extra_python3_packages }}"
+  loop: "{{ install_python3_packages}}"
   when: install_python_version == 3
 
 - name: Update pip to the latest version
   ansible.builtin.pip:
     name:
       - pip
-    # executable: "{{ 'pip3' if install_python_version == 3 else 'pip' }}"
-    extra_args: --upgrade
+    version: "{{ install_pip_version }}"
+    executable: "{{ 'pip3' if install_python_version == 3 else 'pip' }}"
+
+- name: Install Python 2 pip packages
+  ansible.builtin.pip:
+    name: "{{ python2_pip_packages }}"
+  when: install_python_version == 2
+
+- name: Install Python 3 pip packages
+  ansible.builtin.pip:
+    name: "{{ python3_pip_packages }}"
+  when: install_python_version == 3

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,20 +3,20 @@
 - name: Prepare to install Python for the current OS family
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: Install Python 2 and associated packages if necessary # noqa: var-spacing
+- name: Install Python 2 and associated packages if necessary
   ansible.builtin.package:
     name: "{{ item.name | default(item) }}"
     update_cache: true
     state: present
-  loop: "{{ install_python2_packages}}"
+  loop: "{{ install_python2_packages }}"
   when: install_python_version == 2
 
-- name: Install Python 3 and associated packages if necessary # noqa: var-spacing
+- name: Install Python 3 and associated packages if necessary
   ansible.builtin.package:
     name: "{{ item.name | default(item) }}"
     update_cache: true
     state: present
-  loop: "{{ install_python3_packages}}"
+  loop: "{{ install_python3_packages }}"
   when: install_python_version == 3
 
 - name: Update pip to the latest version


### PR DESCRIPTION
Remove the unnecessary variables `extra_python2_packages` and `extra_python3_packages`

Add variables `install_pip_version`, `python3_pip_packages`, `python2_pip_packages` to specify which version of pip to upgrade to and which Python packages to install using pip