### PR TITLE
Better name for task to update pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   loop: "{{ install_python3_packages }}"
   when: install_python_version == 3
 
-- name: Update pip to the latest version
+- name: Update pip
   ansible.builtin.pip:
     name:
       - pip


### PR DESCRIPTION
Rename task to update pip - it's no longer necessarily updated to the latest version