### PR TITLE
Simplify role

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ If you would like to run Ansible Molecule to test this role, the requirements ar
 
 ## Role Variables
 
-`install_python_3_packages`: list of packages to be installed when Python 3 is the default interpreter. This defaults to:
+`install_python` is a dictionary contains the following varialbes:
+
+`version`: the version of Python to install. This defaults to `"3"`.
+
+`pip_version`: the version of pip to update to. This defaults to `"21.3.1"`.
+
+`pip_executable`: path to the pip executalbe to use for installing packages. This defaults to `"pip3"`
+
+`system_packages`: list of system packages to be installed along with Python. This defaults to:
 
 ```yaml
 - python3
@@ -17,21 +25,9 @@ If you would like to run Ansible Molecule to test this role, the requirements ar
 - python3-setuptools
 ```
 
-`install_python2_packages`: list of packages to be installed when Python 2 is the default interpreter. This defaults to:
+The packages listed in `install_python.system_packages` will be installed by the OS package manager, NOT by pip.
 
-```yaml
-- python
-- python-pip
-- python-setuptools
-```
-
-The packages listed in the above variables will be installed by the OS package manager, NOT by pip.
-
-`install_pip_version`: version of pip to update to, defaults to `latest`.
-
-`python3_pip_packages`: list of Python 3 packages to be installed by pip, default to `[]`.
-
-`python2_pip_packages`: list of Python 2 packages to be installed by pip, defaults to `[]`.
+`python3_pip_packages`: list of Python packages to be installed by pip. This defaults to `[]`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you would like to run Ansible Molecule to test this role, the requirements ar
 
 The packages listed in `install_python.system_packages` will be installed by the OS package manager, NOT by pip.
 
-`python3_pip_packages`: list of Python packages to be installed by pip. This defaults to `[]`.
+`pip_packages`: list of Python packages to be installed by pip. This defaults to `[]`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you would like to run Ansible Molecule to test this role, the requirements ar
 
 ## Role Variables
 
-`install_python` is a dictionary contains the following varialbes:
+`install_python` is a dictionary that contains the following varialbes:
 
 `version`: the version of Python to install. This defaults to `"3"`.
 
@@ -35,30 +35,11 @@ There are no Ansible-Galaxy dependencies for this role.
 
 ## Example Playbook
 
-### Basic usage
-
-This role uses the Ansible facts `ansible_os_family` and `ansible_distribution_major_version` to determine whether Python 2 or Python 3
-should be installed on your managed host. As such, you will need to gather these facts when using this role:
+This role will install Python on a managed host. To used this role, add it to the list of roles in a play:
 
 ```yaml
-- name: Install Python 3
+- name: Install Python
   hosts: all
-  gather_facts: true
-  roles:
-    - mirsg.install_python
-```
-
-This will gather all facts before installing Python. If you would like to install only the necessary facts (`ansible_os_family` and `ansible_distribution_major_version`) to run the role and install Python, you can use `gather_subset`:
-
-```yaml
-- name: Install Python 3
-  hosts: all
-  gather_facts: true
-  gather_subset:
-    - "os_family"
-    - "distribution_major_version"
-    - "!min"
-    - "!all"
   roles:
     - mirsg.install_python
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 install_python:
   version: "3"
   pip_version: "21.3.1"
+  pip_executable: "pip3"
   system_packages:
     - python3
     - python3-pip

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,9 @@
 ---
-install_python_version: 3
-install_pip_version: "latest"
-
-install_python3_packages:
-  - python3
-  - python3-pip
-  - python3-setuptools
-
-install_python2_packages:
-  - python
-  - python-pip
-  - python-setuptools
-
-python2_pip_packages: [] # to be installed using pip
-python3_pip_packages: [] # to be installed using pip3
+install_python:
+  version: "3"
+  pip_version: "21.3.1"
+  system_packages:
+    - python3
+    - python3-pip
+    - python3-setuptools
+  pip_packages: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,13 +8,13 @@
     - "!min"
     - "!all"
   pre_tasks:
-    - name: Set Python install version to 2 for older OSes
+    - name: Check the major Python version for the OS
+      ansible.builtin.include_role:
+        name: "mirsg.install_python"
+        tasks_from: "check_default_version"
+    - name: Set install_python variable based on the version to be installed
       ansible.builtin.set_fact:
-        install_python: "{{ install_python2 }}"
-      when: >
-        (ansible_os_family == 'RedHat') and (ansible_distribution_major_version | int < 8) or
-        (ansible_distribution == 'Debian') and (ansible_distribution_major_version | int < 10) or
-        (ansible_distribution == 'Ubuntu') and (ansible_distribution_major_version | int < 18)
+        install_python: "{{ 'install_python2' if default_python_version is version('2') else 'install_python3' }}"
   tasks:
     - name: Install Python, pip, and setuptools
       ansible.builtin.include_role:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,7 +14,7 @@
         tasks_from: "check_default_version"
     - name: Set install_python variable based on the version to be installed
       ansible.builtin.set_fact:
-        install_python: "{{ 'install_python2' if default_python_version is version('2') else 'install_python3' }}"
+        install_python: "{{ install_python2 if default_python_version is version('2') else install_python3 }}"
   tasks:
     - name: Install Python, pip, and setuptools
       ansible.builtin.include_role:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,7 +10,7 @@
   pre_tasks:
     - name: Set Python install version to 2 for older OSes
       ansible.builtin.set_fact:
-        install_python_version: 2
+        install_python: "{{ install_python2 }}"
       when: >
         (ansible_os_family == 'RedHat') and (ansible_distribution_major_version | int < 8) or
         (ansible_distribution == 'Debian') and (ansible_distribution_major_version | int < 10) or

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,11 +21,8 @@ provisioner:
     defaults:
       callbacks_enabled: profile_tasks, timer, yaml
   inventory:
-    group_vars:
-      all:
-        additional_networks: []
-        default_networks:
-          - "0.0.0.0/0"
+    links:
+      group_vars: ../resources/inventory/group_vars/
   env:
     ANSIBLE_VERBOSITY: "1"
 

--- a/molecule/resources/inventory/group_vars/all/vars
+++ b/molecule/resources/inventory/group_vars/all/vars
@@ -1,0 +1,24 @@
+---
+install_python3:
+  version: "3"
+  pip_version: "21.3.1"
+  pip_executable: "pip3"
+  system_packages:
+    - python3
+    - python3-pip
+    - python3-setuptools
+  pip_packages:
+    - cryptography
+
+install_python2:
+  version: "2"
+  pip_version: "20.3.4"
+  pip_executable: "pip"
+  system_packages:
+    - python
+    - python-pip
+    - python-setuptools
+  pip_packages:
+    - cryptography
+
+install_python: "{{ install_python_3 }}" # default to Python 3

--- a/tasks/check_default_version.yml
+++ b/tasks/check_default_version.yml
@@ -1,0 +1,16 @@
+---
+- name: Check if Python 2 is the default version for the OS
+  ansible.builtin.set_fact:
+    default_python_version: "2"
+  when: >
+    (ansible_os_family == 'RedHat') and (ansible_distribution_major_version | int < 8) or
+    (ansible_distribution == 'Debian') and (ansible_distribution_major_version | int < 10) or
+    (ansible_distribution == 'Ubuntu') and (ansible_distribution_major_version | int < 18)
+
+- name: Check if Python 3 is the default version for the OS
+  ansible.builtin.set_fact:
+    default_python_version: "3"
+  when: >
+    (ansible_os_family == 'RedHat') and (ansible_distribution_major_version | int >= 8) or
+    (ansible_distribution == 'Debian') and (ansible_distribution_major_version | int >= 10) or
+    (ansible_distribution == 'Ubuntu') and (ansible_distribution_major_version | int >= 18)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,37 +1,22 @@
 ---
-# tasks file for ansible-role-install-python3
+# tasks file for ansible-role-install-python
 - name: Prepare to install Python for the current OS family
   ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
 
-- name: Install Python 2 and associated packages if necessary
+- name: Install Python and associated system packages
   ansible.builtin.package:
     name: "{{ item.name | default(item) }}"
     update_cache: true
     state: present
-  loop: "{{ install_python2_packages }}"
-  when: install_python_version == 2
-
-- name: Install Python 3 and associated packages if necessary
-  ansible.builtin.package:
-    name: "{{ item.name | default(item) }}"
-    update_cache: true
-    state: present
-  loop: "{{ install_python3_packages }}"
-  when: install_python_version == 3
+  loop: "{{ install_python.system_packages }}"
 
 - name: Update pip
   ansible.builtin.pip:
     name:
       - pip
-    version: "{{ install_pip_version }}"
-    executable: "{{ 'pip3' if install_python_version == 3 else 'pip' }}"
+    version: "{{ install_python.pip_version }}"
+    executable: "{{ install_python.pip_executable }}"
 
-- name: Install Python 2 pip packages
+- name: Install Python pip packages
   ansible.builtin.pip:
-    name: "{{ python2_pip_packages }}"
-  when: install_python_version == 2
-
-- name: Install Python 3 pip packages
-  ansible.builtin.pip:
-    name: "{{ python3_pip_packages }}"
-  when: install_python_version == 3
+    name: "{{ install_python.pip_packages }}"


### PR DESCRIPTION
- Remove duplicated variable names for Python 2 and 3
- Add a task for determining the default version of Python based on the OS. This can be used to set a host fact `default_python_version`
- update README with info about change in variable names